### PR TITLE
Pg users branch

### DIFF
--- a/tests/account/__snapshots__/test_data.ambr
+++ b/tests/account/__snapshots__/test_data.ambr
@@ -223,3 +223,74 @@
     }),
   })
 # ---
+# name: test_update[email][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'email': 'hello@world.com',
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: test_update[email][pg]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[]', primary_group='None')>
+# ---
+# name: test_update[password and email][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'email': 'hello@world.com',
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: test_update[password and email][pg]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[]', primary_group='None')>
+# ---
+# name: test_update[password][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: test_update[password][pg]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[]', primary_group='None')>
+# ---

--- a/tests/account/test_data.py
+++ b/tests/account/test_data.py
@@ -1,10 +1,21 @@
+import asyncio
+import datetime
+
 import pytest
 from aiohttp.test_utils import make_mocked_coro
+from syrupy.filters import props
+from syrupy.matchers import path_type
 from virtool_core.models.enums import Permission
 from virtool_core.models.roles import AdministratorRole
 
-from virtool.account.oas import CreateKeysRequest
+from virtool.account.oas import CreateKeysRequest, UpdateAccountRequest
 from virtool.groups.oas import PermissionsUpdate
+from virtool.pg.utils import get_row_by_id
+from virtool.users.pg import SQLUser
+
+_last_password_change_matcher = path_type(
+    {"last_password_change": (datetime.datetime,)}
+)
 
 
 @pytest.mark.parametrize(
@@ -56,3 +67,37 @@ async def test_create_api_key(
 
     assert api_key == snapshot(name="dl")
     assert await mongo.keys.find_one() == snapshot(name="mongo")
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        UpdateAccountRequest(old_password="hello_world_1", password="hello_world_2"),
+        UpdateAccountRequest(email="hello@world.com"),
+        UpdateAccountRequest(
+            old_password="hello_world_1",
+            password="hello_world_2",
+            email="hello@world.com",
+        ),
+    ],
+    ids=["password", "email", "password and email"],
+)
+async def test_update(data_layer, mongo, pg, fake2, snapshot, update):
+    user = await fake2.users.create(password="hello_world_1")
+
+    await data_layer.account.update(
+        user.id,
+        update,
+    )
+
+    (row, document) = await asyncio.gather(
+        get_row_by_id(pg, SQLUser, 1), mongo.users.find_one({"_id": user.id})
+    )
+
+    assert row == snapshot(
+        name="pg", matcher=_last_password_change_matcher, exclude=props("password")
+    )
+    assert document == snapshot(
+        name="mongo", matcher=_last_password_change_matcher, exclude=props("password")
+    )
+    assert row.password == document["password"]

--- a/tests/fixtures/pg.py
+++ b/tests/fixtures/pg.py
@@ -128,7 +128,7 @@ async def pg(engine: AsyncEngine):
                     spaces,
                     tasks,
                     uploads,
-                    user_group_associations,
+                    user_group,
                     users
                 RESTART IDENTITY
                 """

--- a/tests/groups/test_data.py
+++ b/tests/groups/test_data.py
@@ -10,7 +10,7 @@ from virtool.groups.oas import UpdateGroupRequest
 from virtool.groups.pg import SQLGroup
 from virtool.pg.utils import get_row_by_id
 from virtool.users.oas import UpdateUserRequest
-from virtool.users.pg import user_group_associations
+from virtool.users.pg import UserGroup
 from virtool.users.utils import generate_base_permissions
 
 
@@ -118,18 +118,13 @@ class TestDelete:
         await data_layer.users.update(user.id, UpdateUserRequest(groups=[group.id]))
 
         async with (AsyncSession(pg) as session):
-            users = (
-                (
-                    await session.execute(
-                        select(user_group_associations).where(
-                            user_group_associations.c.group_id == group.id
-                        )
-                    )
+            user_associations = (
+                await session.execute(
+                    select(UserGroup).where(UserGroup.group_id == group.id)
                 )
-                .scalars()
-                .all()
-            )
-        assert len(users) == 1
+            ).all()
+
+        assert len(user_associations) == 1
 
         await data_layer.groups.delete(group.id)
 
@@ -137,16 +132,11 @@ class TestDelete:
 
         async with (AsyncSession(pg) as session):
             users = (
-                (
-                    await session.execute(
-                        select(user_group_associations).where(
-                            user_group_associations.c.group_id == group.id
-                        )
-                    )
+                await session.execute(
+                    select(UserGroup).where(UserGroup.group_id == group.id)
                 )
-                .scalars()
-                .all()
-            )
+            ).all()
+
         assert len(users) == 0
 
     async def test_not_found(self, data_layer: DataLayer):

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -450,6 +450,240 @@
     'legacy_id': 'bf1b993c',
   })
 # ---
+# name: TestUpdate.test_primary_groups[No group][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_primary_groups[No group][obj]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': None,
+  })
+# ---
+# name: TestUpdate.test_primary_groups[No group][pg]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[]', primary_group='None')>
+# ---
+# name: TestUpdate.test_primary_groups[Will be in group][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_primary_groups[Will be in group][obj]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_primary_groups[Will be in group][pg]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
+# ---
+# name: TestUpdate.test_primary_groups[in group][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_primary_groups[in group][obj]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_primary_groups[in group][pg]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
+# ---
+# name: TestUpdate.test_primary_groups[removed from group][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_primary_groups[removed from group][obj]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': None,
+  })
+# ---
+# name: TestUpdate.test_primary_groups[removed from group][pg]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
+# ---
 # name: TestUpdate.test_set_groups[0][groups_after]
   list([
   ])

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -56,11 +56,13 @@
     'b2c_given_name': '',
     'b2c_oid': '',
     'force_reset': False,
+    'groups': [],
     'handle': 'bill',
     'id': 1,
     'invalidate_sessions': False,
     'last_password_change': datetime,
     'legacy_id': 'bf1b993c',
+    'primary_group': None,
   })
 # ---
 # name: TestCreate.test_force_reset[False]
@@ -120,11 +122,13 @@
     'b2c_given_name': '',
     'b2c_oid': '',
     'force_reset': False,
+    'groups': [],
     'handle': 'bill',
     'id': 1,
     'invalidate_sessions': False,
     'last_password_change': datetime,
     'legacy_id': 'bf1b993c',
+    'primary_group': None,
   })
 # ---
 # name: TestCreate.test_force_reset[True]
@@ -184,11 +188,13 @@
     'b2c_given_name': '',
     'b2c_oid': '',
     'force_reset': True,
+    'groups': [],
     'handle': 'bill',
     'id': 1,
     'invalidate_sessions': False,
     'last_password_change': datetime,
     'legacy_id': 'bf1b993c',
+    'primary_group': None,
   })
 # ---
 # name: TestCreate.test_no_force_reset[mongo]
@@ -248,11 +254,13 @@
     'b2c_given_name': '',
     'b2c_oid': '',
     'force_reset': False,
+    'groups': [],
     'handle': 'bill',
     'id': 1,
     'invalidate_sessions': False,
     'last_password_change': datetime,
     'legacy_id': 'bf1b993c',
+    'primary_group': None,
   })
 # ---
 # name: TestUpdate.test_administrator[False][mongo]
@@ -313,11 +321,13 @@
     'b2c_given_name': '',
     'b2c_oid': '',
     'force_reset': False,
+    'groups': [],
     'handle': 'leeashley',
     'id': 1,
     'invalidate_sessions': False,
     'last_password_change': datetime,
     'legacy_id': 'bf1b993c',
+    'primary_group': None,
   })
 # ---
 # name: TestUpdate.test_administrator[True][mongo]
@@ -378,11 +388,13 @@
     'b2c_given_name': '',
     'b2c_oid': '',
     'force_reset': False,
+    'groups': [],
     'handle': 'leeashley',
     'id': 1,
     'invalidate_sessions': False,
     'last_password_change': datetime,
     'legacy_id': 'bf1b993c',
+    'primary_group': None,
   })
 # ---
 # name: TestUpdate.test_password[db]
@@ -443,11 +455,13 @@
     'b2c_given_name': '',
     'b2c_oid': '',
     'force_reset': False,
+    'groups': [],
     'handle': 'bob',
     'id': 1,
     'invalidate_sessions': True,
     'last_password_change': datetime,
     'legacy_id': 'bf1b993c',
+    'primary_group': None,
   })
 # ---
 # name: TestUpdate.test_primary_groups[No group][mongo]
@@ -684,435 +698,6 @@
 # name: TestUpdate.test_primary_groups[removed from group][pg]
   <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
 # ---
-# name: TestUpdate.test_set_groups[0][groups_after]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[0][groups_before]
-  list([
-    GroupMinimal(id=1, legacy_id=None, name='gaffers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[0][groups_mapping_after]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[0][groups_mapping_before]
-  list([
-    {'user_id': 1, 'group_id': 1},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[0][mongo_after]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[0][mongo_before]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 1,
-        'legacy_id': None,
-        'name': 'gaffers',
-      }),
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[0][pg_after]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', primary_group_id='None')>
-# ---
-# name: TestUpdate.test_set_groups[0][pg_before]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', primary_group_id='None')>
-# ---
-# name: TestUpdate.test_set_groups[1][groups_after]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][groups_after_mongo]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][groups_after_pg]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][groups_before]
-  list([
-    GroupMinimal(id=1, legacy_id=None, name='gaffers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][groups_before_mongo]
-  list([
-    GroupMinimal(id=1, legacy_id=None, name='gaffers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][groups_before_pg]
-  list([
-    (<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][groups_mapping_after]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][groups_mapping_before]
-  list([
-    {'user_id': 1, 'group_id': 1, 'is_primary': False},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[1][mongo_after]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[1][mongo_before]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 1,
-        'legacy_id': None,
-        'name': 'gaffers',
-      }),
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[1][pg_after]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime')>
-# ---
-# name: TestUpdate.test_set_groups[1][pg_before]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime')>
-# ---
-# name: TestUpdate.test_set_groups[2][groups_after]
-  list([
-    GroupMinimal(id=2, legacy_id=None, name='actors'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][groups_after_mongo]
-  list([
-    GroupMinimal(id=2, legacy_id=None, name='actors'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][groups_after_pg]
-  list([
-    (<SQLGroup(id=2, legacy_id=None, name=actors, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][groups_before]
-  list([
-    GroupMinimal(id=1, legacy_id=None, name='gaffers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][groups_before_mongo]
-  list([
-    GroupMinimal(id=1, legacy_id=None, name='gaffers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][groups_before_pg]
-  list([
-    (<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][groups_mapping_after]
-  list([
-    {'user_id': 1, 'group_id': 2, 'is_primary': False},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][groups_mapping_before]
-  list([
-    {'user_id': 1, 'group_id': 1, 'is_primary': False},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[2][mongo_after]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 2,
-        'legacy_id': None,
-        'name': 'actors',
-      }),
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[2][mongo_before]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 1,
-        'legacy_id': None,
-        'name': 'gaffers',
-      }),
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[2][pg_after]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime')>
-# ---
-# name: TestUpdate.test_set_groups[2][pg_before]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime')>
-# ---
-# name: TestUpdate.test_set_groups[3][groups_after]
-  list([
-    GroupMinimal(id=2, legacy_id=None, name='actors'),
-    GroupMinimal(id=3, legacy_id=None, name='oceanographers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][groups_after_mongo]
-  list([
-    GroupMinimal(id=2, legacy_id=None, name='actors'),
-    GroupMinimal(id=3, legacy_id=None, name='oceanographers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][groups_after_pg]
-  list([
-    (<SQLGroup(id=2, legacy_id=None, name=actors, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,),
-    (<SQLGroup(id=3, legacy_id=None, name=oceanographers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][groups_before]
-  list([
-    GroupMinimal(id=1, legacy_id=None, name='gaffers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][groups_before_mongo]
-  list([
-    GroupMinimal(id=1, legacy_id=None, name='gaffers'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][groups_before_pg]
-  list([
-    (<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][groups_mapping_after]
-  list([
-    {'user_id': 1, 'group_id': 2, 'is_primary': False},
-    {'user_id': 1, 'group_id': 3, 'is_primary': False},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][groups_mapping_before]
-  list([
-    {'user_id': 1, 'group_id': 1, 'is_primary': False},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[3][mongo_after]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 2,
-        'legacy_id': None,
-        'name': 'actors',
-      }),
-      dict({
-        'id': 3,
-        'legacy_id': None,
-        'name': 'oceanographers',
-      }),
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[3][mongo_before]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 1,
-        'legacy_id': None,
-        'name': 'gaffers',
-      }),
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[3][pg_after]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime')>
-# ---
-# name: TestUpdate.test_set_groups[3][pg_before]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime')>
-# ---
 # name: TestUpdate.test_set_groups[add_groups][mongo_after]
   dict({
     '_id': 'bf1b993c',
@@ -1243,44 +828,6 @@
 # name: TestUpdate.test_set_groups[add_groups][pg_before]
   <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
 # ---
-# name: TestUpdate.test_set_groups[groups_1]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[groups_2]
-  list([
-    GroupMinimal(id=2, legacy_id=None, name='hydrogeologists'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[groups_3]
-  list([
-    GroupMinimal(id=2, legacy_id=None, name='hydrogeologists'),
-    GroupMinimal(id=1, legacy_id=None, name='musicians'),
-  ])
-# ---
-# name: TestUpdate.test_set_groups[groups_4]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[groups_mapping_1]
-  list([
-  ])
-# ---
-# name: TestUpdate.test_set_groups[groups_mapping_2]
-  list([
-    {'user_id': 1, 'group_id': 2},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[groups_mapping_3]
-  list([
-    {'user_id': 1, 'group_id': 2},
-    {'user_id': 1, 'group_id': 1},
-  ])
-# ---
-# name: TestUpdate.test_set_groups[groups_mapping_4]
-  list([
-  ])
-# ---
 # name: TestUpdate.test_set_groups[maintain_groups][mongo_after]
   dict({
     '_id': 'bf1b993c',
@@ -1404,149 +951,6 @@
 # ---
 # name: TestUpdate.test_set_groups[maintain_groups][pg_before]
   <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
-# ---
-# name: TestUpdate.test_set_groups[mongo_1]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'qtaylor',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[mongo_2]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 2,
-        'legacy_id': None,
-        'name': 'hydrogeologists',
-      }),
-    ]),
-    'handle': 'qtaylor',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[mongo_3]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 2,
-        'legacy_id': None,
-        'name': 'hydrogeologists',
-      }),
-      dict({
-        'id': 1,
-        'legacy_id': None,
-        'name': 'musicians',
-      }),
-    ]),
-    'handle': 'qtaylor',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[mongo_4]
-  dict({
-    'active': True,
-    'administrator': False,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'qtaylor',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[pg_1]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='qtaylor', invalidate_sessions='False', last_password_change='datetime', primary_group_id='None')>
-# ---
-# name: TestUpdate.test_set_groups[pg_2]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='qtaylor', invalidate_sessions='False', last_password_change='datetime', primary_group_id='None')>
-# ---
-# name: TestUpdate.test_set_groups[pg_3]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='qtaylor', invalidate_sessions='False', last_password_change='datetime', primary_group_id='None')>
-# ---
-# name: TestUpdate.test_set_groups[pg_4]
-  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='qtaylor', invalidate_sessions='False', last_password_change='datetime', primary_group_id='None')>
 # ---
 # name: TestUpdate.test_set_groups[remove_groups][mongo_after]
   dict({

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -1113,6 +1113,136 @@
 # name: TestUpdate.test_set_groups[3][pg_before]
   <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime')>
 # ---
+# name: TestUpdate.test_set_groups[add_groups][mongo_after]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+      2,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[add_groups][mongo_before]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[add_groups][obj_after]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 2,
+        'legacy_id': None,
+        'name': 'actors',
+      }),
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[add_groups][obj_before]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[add_groups][pg_after]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=2, legacy_id=None, name=actors, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
+# ---
+# name: TestUpdate.test_set_groups[add_groups][pg_before]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
+# ---
 # name: TestUpdate.test_set_groups[groups_1]
   list([
   ])
@@ -1150,6 +1280,130 @@
 # name: TestUpdate.test_set_groups[groups_mapping_4]
   list([
   ])
+# ---
+# name: TestUpdate.test_set_groups[maintain_groups][mongo_after]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[maintain_groups][mongo_before]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[maintain_groups][obj_after]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[maintain_groups][obj_before]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[maintain_groups][pg_after]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
+# ---
+# name: TestUpdate.test_set_groups[maintain_groups][pg_before]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
 # ---
 # name: TestUpdate.test_set_groups[mongo_1]
   dict({
@@ -1293,6 +1547,124 @@
 # ---
 # name: TestUpdate.test_set_groups[pg_4]
   <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='qtaylor', invalidate_sessions='False', last_password_change='datetime', primary_group_id='None')>
+# ---
+# name: TestUpdate.test_set_groups[remove_groups][mongo_after]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[remove_groups][mongo_before]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'administrator': False,
+    'force_reset': False,
+    'groups': list([
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': datetime,
+    'primary_group': 1,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[remove_groups][obj_after]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[remove_groups][obj_before]
+  dict({
+    'active': True,
+    'administrator': False,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': datetime,
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'gaffers',
+    }),
+  })
+# ---
+# name: TestUpdate.test_set_groups[remove_groups][pg_after]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[]', primary_group='None')>
+# ---
+# name: TestUpdate.test_set_groups[remove_groups][pg_before]
+  <SQLUser(id='1', legacy_id='bf1b993c', active='True', administrator='False', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>')>
 # ---
 # name: test_find_or_create_b2c_user[False]
   dict({

--- a/tests/users/test_data.py
+++ b/tests/users/test_data.py
@@ -272,7 +272,7 @@ class TestUpdate:
 
         assert user_obj == snapshot(name="obj", matcher=_last_password_change_matcher)
 
-        (row, document) = await gather(
+        (row, document) = await asyncio.gather(
             *[get_row_by_id(pg, SQLUser, 1), mongo.users.find_one({"_id": user.id})]
         )
 
@@ -312,7 +312,7 @@ class TestUpdate:
         if number_of_groups == 0:
             groups.pop(0)
 
-        (row, document) = await gather(
+        (row, document) = await asyncio.gather(
             *[get_row_by_id(pg, SQLUser, 1), mongo.users.find_one({"_id": user.id})]
         )
 
@@ -330,7 +330,7 @@ class TestUpdate:
             user.id, UpdateUserRequest(groups=[group.id for group in groups])
         )
 
-        (row, document) = await gather(
+        (row, document) = await asyncio.gather(
             *[get_row_by_id(pg, SQLUser, 1), mongo.users.find_one({"_id": user.id})]
         )
 

--- a/virtool/users/data.py
+++ b/virtool/users/data.py
@@ -1,11 +1,9 @@
 import asyncio
 import random
 
-
 from pymongo.errors import DuplicateKeyError
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy.orm import selectinload
 from virtool_core.models.roles import AdministratorRole
 from virtool_core.models.user import User, UserSearchResult
 

--- a/virtool/users/pg.py
+++ b/virtool/users/pg.py
@@ -70,6 +70,7 @@ class SQLUser(Base):
         back_populates="user",
         lazy="joined",
         primaryjoin="and_(user_group.c.user_id == SQLUser.id, user_group.c.is_primary == True)",
+        viewonly=True,
     )
 
     primary_group: AssociationProxy[SQLGroup] = AssociationProxy(

--- a/virtool/users/pg.py
+++ b/virtool/users/pg.py
@@ -66,16 +66,15 @@ class SQLUser(Base):
         creator=lambda group: UserGroup(group=group),
     )
 
-    primary_group_association: Mapped[List[UserGroup]] = relationship(
+    primary_group_association: Mapped[UserGroup] = relationship(
         back_populates="user",
         lazy="joined",
         primaryjoin="and_(user_group.c.user_id == SQLUser.id, user_group.c.is_primary == True)",
     )
 
-    primary_group: AssociationProxy[List[SQLGroup]] = AssociationProxy(
+    primary_group: AssociationProxy[SQLGroup] = AssociationProxy(
         "primary_group_association",
         "group",
-        creator=lambda group: UserGroup(group=group),
     )
 
     def to_dict(self):


### PR DESCRIPTION
Changes:

  - Uses association object for handling the intermediate table to ensure ORM stays up to date as reccomneded in SQLAlchemy docs
  - Creates functional tests for testing the primary group
  - rework test_set_groups to ensure that the association is working as expected
  - Corrected case in `account` view where a mongo user could be updated and the postgres user ignored
  - Prevents crashing while updating users if the SQL user does not exist

**Notes:**
Overall this solution works well. No major technical problems. That said the update function is a bit more janky than I would like. Using the ORM when no user exists results in a crash, but using the association proxies to assign groups pretty much requires use of the ORM.

Additionally this version still needs to account for Administrator variable removal from pg